### PR TITLE
Libav: mark ffmpeg conflict, other improvements

### DIFF
--- a/Formula/libav.rb
+++ b/Formula/libav.rb
@@ -24,6 +24,9 @@ class Libav <Formula
   depends_on 'opencore-amr' => :optional
   depends_on 'libass' => :optional
 
+  conflicts_with 'ffmpeg',
+    :because => 'libav and ffmpeg install the same libraries'
+
   def options
     [
       ["--with-avplay", "Build avplay."]

--- a/Formula/libav.rb
+++ b/Formula/libav.rb
@@ -1,10 +1,10 @@
 require 'formula'
 
 def avplay?
-  ARGV.include? '--with-avplay'
+  build.include? 'with-avplay'
 end
 
-class Libav <Formula
+class Libav < Formula
   head 'git://git.libav.org/libav.git', :using => :git,
     :ref => '4f935a7b89e44fc0fd05c340c17bddcb6a407cb'
   homepage 'http://www.libav.org/'
@@ -27,16 +27,11 @@ class Libav <Formula
   conflicts_with 'ffmpeg',
     :because => 'libav and ffmpeg install the same libraries'
 
-  def options
-    [
-      ["--with-avplay", "Build avplay."]
-    ]
-  end
+  option 'with-avplay', 'Build avplay'
 
   depends_on 'sdl' if avplay?
 
   def install
-    ENV.x11
     args = ["--prefix=#{prefix}",
             "--cc=#{ENV.cc}",
             "--disable-debug",

--- a/Formula/libav.rb
+++ b/Formula/libav.rb
@@ -9,7 +9,6 @@ class Libav < Formula
     :ref => '4f935a7b89e44fc0fd05c340c17bddcb6a407cb'
   homepage 'http://www.libav.org/'
 
-  depends_on :x11
   depends_on 'pkg-config' => :build
   depends_on 'yasm' => :build
 
@@ -28,7 +27,9 @@ class Libav < Formula
     :because => 'libav and ffmpeg install the same libraries'
 
   option 'with-avplay', 'Build avplay'
+  option 'with-freetype', 'Enable FreeType'
 
+  depends_on :freetype if build.include? 'with-freetype'
   depends_on 'sdl' if avplay?
 
   def install


### PR DESCRIPTION
These commits add a few improvements to your libav formula:
- Mark the conflict on ffmpeg (so users will be notified before the build, rather than when they get links failing at the end).
- Change the :x11 dep to a :freetype dep, which is lighterweight for Mountain Lion users. This will use X11/XQuartz when it's available, but for Mountain Lion users who don't have XQuartz it'll pull in Homebrew's freetype instead.
- Various style improvements, including migrating options over to the new option DSL.
