### PR TITLE
mplayer: remove unnecessary :build requirements

### DIFF
--- a/Formula/mplayer2.rb
+++ b/Formula/mplayer2.rb
@@ -13,16 +13,16 @@ class Mplayer2 < Formula
   depends_on 'pkg-config' => :build
   depends_on 'python3' => :build
 
-  depends_on 'libbs2b' => :build
-  depends_on 'libass' => :build
-  depends_on 'mpg123' => :build
-  depends_on 'libmad' => :build
-  depends_on 'libdvdnav' => :build
+  depends_on 'libbs2b'
+  depends_on 'libass'
+  depends_on 'mpg123'
+  depends_on 'libmad'
+  depends_on 'libdvdnav'
 
   if libav?
-    depends_on 'pigoz/mplayer2/libav' => :build
+    depends_on 'pigoz/mplayer2/libav'
   else
-    depends_on 'ffmpeg' => :build
+    depends_on 'ffmpeg'
   end
 
   unless libav?


### PR DESCRIPTION
`depends_on 'foo' => :build` indicates that the dependency is only required at buildtime and isn't needed by the software when run normally, e.g. like pkg-config. It shouldn't be used for dependencies that are required after the software is built.

I wasn't sure whether python3 is only used during build or whether it's actually required at runtime, so I didn't change it. You might want to change that too if it's required past the build phase.
