### PR TITLE
mplayer2: correct manpage name

### DIFF
--- a/Formula/mplayer2.rb
+++ b/Formula/mplayer2.rb
@@ -52,7 +52,8 @@ class Mplayer2 < Formula
     system "./configure", *args
     system "make install"
 
-    mv bin + 'mplayer', bin + binary_name
+    mv bin/'mplayer', bin/binary_name
+    mv man1/'mplayer.1', man1/(binary_name + '.1')
   end
 
   private


### PR DESCRIPTION
The 'mplayer' binary is installed as 'mplayer2' (presumably to avoid conflicts with the original), but the manpage was still being installed as 'mplayer.1'.

(An alternative to this would be to skip `make install` entirely, and just use:

``` ruby
system "make"
bin.install 'mplayer' => 'mplayer2'
man1.install 'DOCS/man/en/mplayer.1' => 'mplayer2.1'
```

)
